### PR TITLE
Port: Added PUBLIC_PORT to fix redirects when running on a port != 80.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,6 @@ mplx <developer@mplx.eu> <mplx+coding@donotreply.at> <mplx@donotreply.at>
 #
 
 # sign CLA below "name <author@sample.tld>"
+
+juergen kellerer <juergen@k123.eu>
+

--- a/readme.md
+++ b/readme.md
@@ -58,9 +58,13 @@ StrictHostKeyChecking=no
 UserKnownHostsFile=/dev/null 
 ```
 
+## public port `PUBLIC_PORT`
+
+nginx uses port 80 by default. If you require another port you can change this via `PUBLIC_PORT` (e.g. `docker run ... -e PUBLIC_PORT=443 ...`). Webvirtcloud uses `PUBLIC_PORT` for redirections (e.g. to login page) therefore it should be set when the web UI is accessed via a port other than 80 or 443. 
+
 ## novncd `VNC_PORT`
 
-websocket connections for vnc/spice are proxied through nginx which defaults to port 80. If you require another port (i.e. you're using webvirtcloud behind a SSL proxy ) you'll have to set up the appropiate port (`docker run ... -e VNC_PORT=443 ...`).
+websocket connections for vnc/spice are proxied through nginx which defaults to port 80 (or `PUBLIC_PORT` if set). If you require another port (i.e. you're using webvirtcloud behind a SSL proxy ) you'll have to set up the appropiate port (`docker run ... -e VNC_PORT=443 ...`).
 
 ## Proxy
 

--- a/startinit.sh
+++ b/startinit.sh
@@ -16,6 +16,13 @@ echo "Your WebVirtCloud public key:"
 cat /var/www/.ssh/id_rsa.pub
 echo ""
 
+# set public port
+if [ -n "$PUBLIC_PORT" ]; then
+	sed -r -i "s/(\\s*listen )[0-9]+;/\\1${PUBLIC_PORT};/" /etc/nginx/conf.d/webvirtcloud.conf
+
+	[ -n "$VNC_PORT" ] || VNC_PORT=$PUBLIC_PORT
+fi
+
 # set vnc port
 if [ -n "$VNC_PORT" ]; then
 	sed -i "s/WS_PUBLIC_PORT = [0-9]\+/WS_PUBLIC_PORT = $VNC_PORT/" /srv/webvirtcloud/webvirtcloud/settings.py


### PR DESCRIPTION
Hi mplx,

Thanks a lot for your project it helps to dockerize webvirtcloud.

When using it on ports != 80, I've found that redirects (e.g. to login page) don't work as webvirtcloud thinks it runs on port 80 (due to the proxy headers forwarded by nginx).

One solution would have been to modify the proxy headers to tell webvirtcloud what the outside port is. However I found it more straight forward to change the nginx port config.

Hope you find this useful.

Best regards, Juergen